### PR TITLE
chore: ライセンス情報を追加

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -10,3 +10,5 @@ layers:
     path: build
     name: ghostscript-aws-lambda-layer
     description: Ghostscript v9.53.3 (/opt/bin/gs)
+    licenseInfo: AGPL-3.0
+    retain: true


### PR DESCRIPTION
Serverless FrameworkからLayerのライセンス情報を追加できたので、追加しました。
AWS LambdaのConsoleに表示されるようになります。

また、Layerのバージョンを保持しておかないと、利用しているStackをRollbackする際に、対応するバージョンが消失していて戻せないということが起こるので、 `retain: true` を指定するように変更します。